### PR TITLE
Fixed vh bug on mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -416,7 +416,7 @@ nav {
 
 header {
     position: relative;
-    height: calc(100vh - 60px);
+    height: calc(100vh);
     margin-bottom: 60px;
     background-image: url("../img/header1.jpg");
     background-size: cover;

--- a/index.php
+++ b/index.php
@@ -144,8 +144,7 @@ $tournament[] = getcontent(2);
                 <div id='magic-line' />
         </nav>
 
-        <header>
-
+        <header id="header">
             <section class="logo-header" id="home">
             </section>
             <div class="clearfix"></div>
@@ -510,6 +509,14 @@ $tournament[] = getcontent(2);
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
         <script src="assets/js/functions.js"></script>
         <script src="assets/js/email_responsivnews.js"></script>
+        <script>
+            function calcVH() {
+                var vH = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+                document.getElementById("header").setAttribute("style", "height:" + (vH - 60) + "px;");
+            }
+            calcVH();
+            window.addEventListener('onorientationchange', calcVH, true);
+        </script>
     </body>
 
     </html>


### PR DESCRIPTION
This fixes the bug that the header does not have a 60px margin to the screen bottom. However it creates a new bug.

The original bug appears when you load the page on mobile in most browsers (Android & IOS). The navigation bar of the browser is not excluded from the vh units (in most browsers... Facebook browser does that...). So everything get pushed down by its height which caused the problem that there was no 60px margin to the screen bottom and the FAB was not completely visible.
This inline js fixes the problem.

It sets the element height(should be 100vh - 60px) to the window height - 60px. The new value does not contain the vh unit and fixes the bug...

The new bug can get created like this:
Scroll down now, so the navigation disappears, and the click on the home button so the website scrolls up again without letting the navigation bar appear again. That is where everything looked nice before the fix(60px margin etc.). Now the height of the header has the navigation bar height excluded so without the navigation bar you can already see the news h1 in this situation.

We have to decide wether or not we want it to look nice when the page loads or when the user scrolls down and clicks on the home button.